### PR TITLE
Add flag for enabling stack termination protection on CF stacks

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7663465ebd8fdf54963bc40a6071e0b78504f847430a0b76698a8791a83431e7
-updated: 2017-11-29T18:28:54.766058707+01:00
+hash: 628358c762eb3a7c9a33a508e803f452b0d4b5ecd405933ddcd36d3466326a6b
+updated: 2018-03-05T16:46:30.276886461+01:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -8,7 +8,7 @@ imports:
 - name: github.com/alecthomas/units
   version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - name: github.com/aws/aws-sdk-go
-  version: 80bf27afd5602f55c398d43621b9900583df3661
+  version: aace5875a5c3b85a3902c6d72b9caed301d64cce
   subpackages:
   - aws
   - aws/awserr
@@ -26,6 +26,7 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/sdkrand
   - internal/shareddefaults
   - private/protocol
   - private/protocol/ec2query
@@ -42,6 +43,8 @@ imports:
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
+- name: github.com/cenkalti/backoff
+  version: 61153c768f31ee5f130071d08fc82b85208528de
 - name: github.com/crewjam/go-cloudformation
   version: d3183a4759da92da1e846521444ad08216b7f20e
 - name: github.com/davecgh/go-spew

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,3 +17,5 @@ import:
   version: ^1.12.29
   subpackages:
   - service/cloudformation
+- package: github.com/cenkalti/backoff
+  version: ~1.1.0

--- a/main.go
+++ b/main.go
@@ -46,16 +46,18 @@ type Config struct {
 	// required by AWS provider
 	NatCidrBlocks []string
 	// required by AWS provider
-	AvailabilityZones []string
+	AvailabilityZones          []string
+	StackTerminationProtection bool
 }
 
 var defaultConfig = &Config{
-	Master:     "",
-	KubeConfig: "",
-	DryRun:     false,
-	LogFormat:  "text",
-	LogLevel:   log.InfoLevel.String(),
-	Provider:   "noop",
+	Master:                     "",
+	KubeConfig:                 "",
+	DryRun:                     false,
+	LogFormat:                  "text",
+	LogLevel:                   log.InfoLevel.String(),
+	Provider:                   "noop",
+	StackTerminationProtection: false,
 }
 
 func NewConfig() *Config {
@@ -91,6 +93,7 @@ Example:
 	app.Flag("provider", "Provider implementing static egress <noop|aws> (default: auto-detect)").Default(defaultConfig.Provider).StringVar(&cfg.Provider)
 	app.Flag("aws-nat-cidr-block", "AWS Provider requires to specify NAT-CIDR-Blocks for each AZ to have a NAT gateway in. Each should be a small network having only the NAT GW").StringsVar(&cfg.NatCidrBlocks)
 	app.Flag("aws-az", "AWS Provider requires to specify all AZs to have a NAT gateway in.").StringsVar(&cfg.AvailabilityZones)
+	app.Flag("stack-termination-protection", "Enables AWS clouformation stack termination protection for the stacks managed by the controller.").BoolVar(&cfg.StackTerminationProtection)
 	app.Flag("flush-interval", "Minimum interval to call provider on change events.").Default("5s").DurationVar(&flushToProviderInterval)
 	app.Flag("dry-run", "When enabled, prints changes rather than actually performing them (default: disabled)").BoolVar(&cfg.DryRun)
 	app.Flag("log-level", "Set the level of logging. (default: info, options: panic, debug, info, warn, error, fatal").Default(defaultConfig.LogLevel).EnumVar(&cfg.LogLevel, allLogLevelsAsStrings()...)
@@ -122,7 +125,7 @@ func main() {
 	log.SetLevel(ll)
 	log.Debugf("config: %+v", cfg)
 
-	p := provider.NewProvider(cfg.DryRun, cfg.Provider, cfg.NatCidrBlocks, cfg.AvailabilityZones)
+	p := provider.NewProvider(cfg.DryRun, cfg.Provider, cfg.NatCidrBlocks, cfg.AvailabilityZones, cfg.StackTerminationProtection)
 	run(newKubeClient(), p)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -169,7 +169,7 @@ func Test_enterProvider(t *testing.T) {
 		{
 			name:     "enterProvider noop quit test",
 			wg:       sync.WaitGroup{},
-			p:        provider.NewProvider(true, noop.ProviderName, []string{}, []string{}),
+			p:        provider.NewProvider(true, noop.ProviderName, []string{}, []string{}, false),
 			mergerCH: make(chan []string),
 			quitCH:   make(chan struct{}),
 			timeout:  3 * time.Second,

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -35,7 +35,7 @@ func TestGenerateStackSpec(t *testing.T) {
 	natCidrBlocks := []string{"172.31.64.0/28"}
 	availabilityZones := []string{"eu-central-1a"}
 	destinationCidrBlocks := []string{"213.95.138.236/32"}
-	p := NewAwsProvider(true, natCidrBlocks, availabilityZones)
+	p := NewAwsProvider(true, natCidrBlocks, availabilityZones, false)
 	fakeVpcsResp := ec2.DescribeVpcsOutput{
 		Vpcs: []*ec2.Vpc{
 			&ec2.Vpc{
@@ -90,7 +90,7 @@ func TestGenerateTemplate(t *testing.T) {
 	natCidrBlocks := []string{"172.31.64.0/28"}
 	availabilityZones := []string{"eu-central-1a"}
 	destinationCidrBlocks := []string{"213.95.138.236/32"}
-	p := NewAwsProvider(true, natCidrBlocks, availabilityZones)
+	p := NewAwsProvider(true, natCidrBlocks, availabilityZones, false)
 	expect := `{"AWSTemplateFormatVersion":"2010-09-09","Description":"Static Egress Stack","Parameters":{"AZ1RouteTableIDParameter":{"Type":"String","Description":"Route Table ID Availability Zone 1"},"DestinationCidrBlock1":{"Type":"String","Default":"213.95.138.236/32","Description":"Destination CIDR Block 1"},"InternetGatewayIDParameter":{"Type":"String","Description":"Internet Gateway ID"},"VPCIDParameter":{"Type":"AWS::EC2::VPC::Id","Description":"VPC ID"}},"Resources":{"EIP1":{"Type":"AWS::EC2::EIP","Properties":{"Domain":"vpc"}},"NATGateway1":{"Type":"AWS::EC2::NatGateway","Properties":{"AllocationId":{"Fn::GetAtt":["EIP1","AllocationId"]},"SubnetId":{"Ref":"NATSubnet1"}}},"NATSubnet1":{"Type":"AWS::EC2::Subnet","Properties":{"AvailabilityZone":"eu-central-1a","CidrBlock":"172.31.64.0/28","Tags":[{"Key":"Name","Value":"nat-eu-central-1a"}],"VpcId":{"Ref":"VPCIDParameter"}}},"NATSubnetRoute1":{"Type":"AWS::EC2::Route","Properties":{"DestinationCidrBlock":"0.0.0.0/0","GatewayId":{"Ref":"InternetGatewayIDParameter"},"RouteTableId":{"Ref":"NATSubnetRouteTable1"}}},"NATSubnetRouteTable1":{"Type":"AWS::EC2::RouteTable","Properties":{"VpcId":{"Ref":"VPCIDParameter"}}},"NATSubnetRouteTableAssociation1":{"Type":"AWS::EC2::SubnetRouteTableAssociation","Properties":{"RouteTableId":{"Ref":"NATSubnetRouteTable1"},"SubnetId":{"Ref":"NATSubnet1"}}},"RouteToNAT1z213x95x138x236y32":{"Type":"AWS::EC2::Route","Properties":{"DestinationCidrBlock":{"Ref":"DestinationCidrBlock1"},"NatGatewayId":{"Ref":"NATGateway1"},"RouteTableId":{"Ref":"AZ1RouteTableIDParameter"}}}},"Outputs":{"EIP1":{"Description":"external IP of the NATGateway1","Value":{"Ref":"EIP1"}}}}`
 	template := p.generateTemplate(destinationCidrBlocks)
 	if template != expect {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -13,10 +13,10 @@ type Provider interface {
 	String() string
 }
 
-func NewProvider(dry bool, name string, natCidrBlocks, availabilityZones []string) Provider {
+func NewProvider(dry bool, name string, natCidrBlocks, availabilityZones []string, StackTerminationProtection bool) Provider {
 	switch name {
 	case aws.ProviderName:
-		return aws.NewAwsProvider(dry, natCidrBlocks, availabilityZones)
+		return aws.NewAwsProvider(dry, natCidrBlocks, availabilityZones, StackTerminationProtection)
 	case noop.ProviderName:
 		return noop.NewNoopProvider()
 	default:


### PR DESCRIPTION
Adds a flag `stack-termination-protection` for enabling the termination
protection feature of cloudformation. This is to make it harder for
users to accidentally delete infrastructure stacks.

Similar to: https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/134