### PR TITLE
AlreadyExistsException check on stackcreation. 

### DIFF
--- a/main.go
+++ b/main.go
@@ -290,8 +290,6 @@ func enterProvider(wg *sync.WaitGroup, p provider.Provider, mergerCH <-chan []st
 					if err != nil {
 						log.Error(err)
 					}
-				default:
-					log.Errorf("updating stack err: %v at time: %v", err, t)
 				}
 			}
 			if len(input) == 0 { // not caused by faulty value in CIDR string

--- a/main.go
+++ b/main.go
@@ -6,18 +6,18 @@ import (
 	"os"
 	"os/signal"
 	"sort"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/cenkalti/backoff"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/szuecs/kube-static-egress-controller/kube"
-	provider "github.com/szuecs/kube-static-egress-controller/provider"
+	"github.com/szuecs/kube-static-egress-controller/provider"
+	"github.com/szuecs/kube-static-egress-controller/provider/aws"
+	"github.com/szuecs/kube-static-egress-controller/provider/noop"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -62,6 +62,18 @@ var defaultConfig = &Config{
 
 func NewConfig() *Config {
 	return &Config{}
+}
+
+func newProvider(dry bool, name string, natCidrBlocks, availabilityZones []string, StackTerminationProtection bool) provider.Provider {
+	switch name {
+	case aws.ProviderName:
+		return aws.NewAwsProvider(dry, natCidrBlocks, availabilityZones, StackTerminationProtection)
+	case noop.ProviderName:
+		return noop.NewNoopProvider()
+	default:
+		log.Fatalf("Unkown provider: %s", name)
+	}
+	return nil
 }
 
 func allLogLevelsAsStrings() []string {
@@ -125,7 +137,7 @@ func main() {
 	log.SetLevel(ll)
 	log.Debugf("config: %+v", cfg)
 
-	p := provider.NewProvider(cfg.DryRun, cfg.Provider, cfg.NatCidrBlocks, cfg.AvailabilityZones, cfg.StackTerminationProtection)
+	p := newProvider(cfg.DryRun, cfg.Provider, cfg.NatCidrBlocks, cfg.AvailabilityZones, cfg.StackTerminationProtection)
 	run(newKubeClient(), p)
 }
 
@@ -270,18 +282,16 @@ func enterProvider(wg *sync.WaitGroup, p provider.Provider, mergerCH <-chan []st
 				bootstrap = false
 				continue
 			}
-
 			var err error
 			createNotify := func(err error, t time.Duration) {
-				log.Errorf("%v at time: %v", err, t)
-				if awsErr, ok := err.(awserr.Error); ok {
-					if awsErr.Code() == "AlreadyExistsException" {
-						log.Debugf("got AlreadyExistsException on Stack creation, trying to update it")
-						err = p.Update(output)
-						if err != nil {
-							log.Error(err)
-						}
+				switch errors.Cause(err).(type) {
+				case *provider.AlreadyExistsError:
+					err = p.Update(output)
+					if err != nil {
+						log.Error(err)
 					}
+				default:
+					log.Errorf("updating stack err: %v at time: %v", err, t)
 				}
 			}
 			if len(input) == 0 { // not caused by faulty value in CIDR string
@@ -307,19 +317,17 @@ func enterProvider(wg *sync.WaitGroup, p provider.Provider, mergerCH <-chan []st
 						err = p.Update(output)
 						// create if stack does not exist, but we have targets
 						if err != nil {
-							switch e := errors.Cause(err).(type) {
-							case awserr.Error:
-								log.Infof("%s | %s | %s", e.Code(), e.Message(), e.OrigErr())
-								if strings.Contains(e.Message(), "does not exist") {
-									err = p.Create(output)
-									createFunc := func() error {
-										return p.Create(output)
-									}
-									err = backoff.RetryNotify(createFunc, retry, createNotify)
-									if err != nil {
-										log.Error(err)
-									}
+							switch errors.Cause(err).(type) {
+							case *provider.DoesNotExistError:
+								createFunc := func() error {
+									return p.Create(output)
 								}
+								err = backoff.RetryNotify(createFunc, retry, createNotify)
+								if err != nil {
+									log.Error(err)
+								}
+							default:
+								log.Errorf("updating stack err: %v", err)
 							}
 						}
 					}

--- a/main.go
+++ b/main.go
@@ -325,7 +325,7 @@ func enterProvider(wg *sync.WaitGroup, p provider.Provider, mergerCH <-chan []st
 									log.Error(err)
 								}
 							default:
-								log.Errorf("updating stack err: %v", err)
+								log.Errorf("Failed to update stack: %v", err)
 							}
 						}
 					}

--- a/main_test.go
+++ b/main_test.go
@@ -169,7 +169,7 @@ func Test_enterProvider(t *testing.T) {
 		{
 			name:     "enterProvider noop quit test",
 			wg:       sync.WaitGroup{},
-			p:        provider.NewProvider(true, noop.ProviderName, []string{}, []string{}, false),
+			p:        newProvider(true, noop.ProviderName, []string{}, []string{}, false),
 			mergerCH: make(chan []string),
 			quitCH:   make(chan struct{}),
 			timeout:  3 * time.Second,

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -113,7 +113,7 @@ func (p *AwsProvider) Create(nets []string) error {
 
 	stackID, err := p.createCFStack(nets, &spec)
 	if err != nil {
-		return errors.Wrap(err, "failed to create CF stack")
+		return err
 	}
 	log.Infof("%s: Created CF Stack %s", p, stackID)
 	return nil

--- a/provider/error.go
+++ b/provider/error.go
@@ -1,0 +1,25 @@
+package provider
+
+type AlreadyExistsError struct {
+	Msg string
+}
+
+type DoesNotExistError struct {
+	Msg string
+}
+
+func (error *AlreadyExistsError) Error() string {
+	return error.Msg
+}
+
+func (error *DoesNotExistError) Error() string {
+	return error.Msg
+}
+
+func NewAlreadyExistsError(text string) error {
+	return &AlreadyExistsError{text}
+}
+
+func NewDoesNotExistError(text string) error {
+	return &DoesNotExistError{text}
+}

--- a/provider/error.go
+++ b/provider/error.go
@@ -1,25 +1,25 @@
 package provider
 
 type AlreadyExistsError struct {
-	Msg string
+	msg string
 }
 
 type DoesNotExistError struct {
-	Msg string
+	msg string
 }
 
 func (error *AlreadyExistsError) Error() string {
-	return error.Msg
+	return error.msg
 }
 
 func (error *DoesNotExistError) Error() string {
-	return error.Msg
+	return error.msg
 }
 
-func NewAlreadyExistsError(text string) error {
-	return &AlreadyExistsError{text}
+func NewAlreadyExistsError(msg string) error {
+	return &AlreadyExistsError{msg}
 }
 
-func NewDoesNotExistError(text string) error {
-	return &DoesNotExistError{text}
+func NewDoesNotExistError(msg string) error {
+	return &DoesNotExistError{msg}
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,26 +1,8 @@
 package provider
 
-import (
-	log "github.com/sirupsen/logrus"
-	"github.com/szuecs/kube-static-egress-controller/provider/aws"
-	"github.com/szuecs/kube-static-egress-controller/provider/noop"
-)
-
 type Provider interface {
 	Create([]string) error
 	Update([]string) error
 	Delete() error
 	String() string
-}
-
-func NewProvider(dry bool, name string, natCidrBlocks, availabilityZones []string, StackTerminationProtection bool) Provider {
-	switch name {
-	case aws.ProviderName:
-		return aws.NewAwsProvider(dry, natCidrBlocks, availabilityZones, StackTerminationProtection)
-	case noop.ProviderName:
-		return noop.NewNoopProvider()
-	default:
-		log.Fatalf("Unkown provider: %s", name)
-	}
-	return nil
 }


### PR DESCRIPTION
We've got a dead-loop case for stack creation function, Here is log that is repeating now for couple of days in console output: 
This happened after we've removed one of the egress configmaps. 

```
time="2018-10-01T07:54:43Z" level=info msg="aws: Create([xx.xx.xx.xx/32 y.y.y.y/32 zz.zz.zz.zz/32])"
time="2018-10-01T07:54:43Z" level=debug msg=RouteToNAT1z
time="2018-10-01T07:54:43Z" level=debug msg=RouteToNAT2z
time="2018-10-01T07:54:43Z" level=debug msg=RouteToNAT3z
time="2018-10-01T07:54:43Z" level=debug msg=RouteToNAT1z
time="2018-10-01T07:54:43Z" level=debug msg=RouteToNAT2z
time="2018-10-01T07:54:43Z" level=debug msg=RouteToNAT3z
time="2018-10-01T07:54:43Z" level=debug msg=RouteToNAT1z
time="2018-10-01T07:54:43Z" level=debug msg=RouteToNAT2z
time="2018-10-01T07:54:43Z" level=debug msg=RouteToNAT3z
time="2018-10-01T07:54:43Z" level=debug msg="aws: vpcs(1)"
time="2018-10-01T07:54:43Z" level=debug msg="aws: igw(1)"
time="2018-10-01T07:54:43Z" level=debug msg="aws: rt(3)"
time="2018-10-01T07:54:43Z" level=debug msg="Stackoutput: {\n\n}"
time="2018-10-01T07:59:43Z" level=info msg="aws: Create([xx.xx.xx.xx/32 y.y.y.y/32 zz.zz.zz.zz/32])"
time="2018-10-01T07:59:43Z" level=debug msg=RouteToNAT1z
time="2018-10-01T07:59:43Z" level=debug msg=RouteToNAT2z
time="2018-10-01T07:59:43Z" level=debug msg=RouteToNAT3z
time="2018-10-01T07:59:43Z" level=debug msg=RouteToNAT1z
time="2018-10-01T07:59:43Z" level=debug msg=RouteToNAT2z
time="2018-10-01T07:59:43Z" level=debug msg=RouteToNAT3z
time="2018-10-01T07:59:43Z" level=debug msg=RouteToNAT1z
time="2018-10-01T07:59:43Z" level=debug msg=RouteToNAT2z
time="2018-10-01T07:59:43Z" level=debug msg=RouteToNAT3z
time="2018-10-01T07:59:43Z" level=debug msg="aws: vpcs(1)"
time="2018-10-01T07:59:43Z" level=debug msg="aws: igw(1)"
time="2018-10-01T07:59:43Z" level=debug msg="aws: rt(3)"
time="2018-10-01T07:59:43Z" level=debug msg="Stackoutput: {\n\n}"

```
And for some reason controller started `p.Create` function in loop probably after initial "p.Update(output)" failed. 
changed `backoff.Retry` to `backoff.RetryNotify` for `p.Create` with a notify to `createNotify` func that has extra condition for AlreadyExistsException. 


