### PR TITLE
Handle stacks already exists

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func run(client kubernetes.Interface, p provider.Provider) {
 
 	// quit
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigs, syscall.SIGTERM)
 	<-sigs
 	for i := 0; i < 3; i++ {
 		log.Infof("send quit to all %d", i)

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -368,6 +368,8 @@ func (p *AwsProvider) createCFStack(nets []string, spec *stackSpec) (string, err
 			if awsErr, ok := err.(awserr.Error); ok {
 				if strings.Contains(awsErr.Message(), "does not exist") {
 					err = provider.NewDoesNotExistError(fmt.Sprintf("%s does not exist", stackName))
+				} else if awsErr.Code() == "AlreadyExistsException" {
+					err = provider.NewAlreadyExistsError(fmt.Sprintf("%s AlreadyExists", stackName))
 				}
 			}
 			return spec.name, err


### PR DESCRIPTION
This fixes a bug where the controller would not update the CF stack in case it had a new IP to add.

The bug happened because the createStack function didn't return the correct `AlreadyExistsError` which is checked when deciding if the stack should be updated instead of created.

Also removes handling of SIGINT so you can `ctrl+C` when running locally.