### PR TITLE
Initialize cache at startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,19 @@
-os:
-- linux
-
 language: go
 
 go:
-- 1.x
+- "1.12.x"
 - tip
 
 matrix:
   allow_failures:
   - go: tip
 
-before_install:
-- go get github.com/Masterminds/glide
+env:
+- GO111MODULE=on
 
-install:
-- glide install --strip-vendor
+before_install:
+- go get honnef.co/go/tools/cmd/staticcheck
 
 script:
-- make
+- make build.docker
 - make test

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -42,6 +42,7 @@ func (c *EgressController) Run(ctx context.Context) {
 			configs, err := c.configSource.ListConfigs()
 			if err != nil {
 				log.Errorf("Failed to list Egress configurations: %v", err)
+				time.Sleep(3 * time.Second)
 				continue
 			}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -8,21 +8,27 @@ import (
 	"github.com/szuecs/kube-static-egress-controller/provider"
 )
 
+type EgressConfigSource interface {
+	ListConfigs() ([]provider.EgressConfig, error)
+	Config() <-chan provider.EgressConfig
+}
+
 // EgressController is the controller for creating Egress configuration via a
 // provider.
 type EgressController struct {
-	interval     time.Duration
-	configsChan  <-chan provider.EgressConfig
-	configsCache map[provider.Resource]map[string]struct{}
-	provider     provider.Provider
+	interval         time.Duration
+	configSource     EgressConfigSource
+	configsCache     map[provider.Resource]map[string]struct{}
+	provider         provider.Provider
+	cacheInitialized bool
 }
 
 // NewEgressController initializes a new EgressController.
-func NewEgressController(prov provider.Provider, configsChan <-chan provider.EgressConfig, interval time.Duration) *EgressController {
+func NewEgressController(prov provider.Provider, configSource EgressConfigSource, interval time.Duration) *EgressController {
 	return &EgressController{
 		interval:     interval,
-		configsChan:  configsChan,
 		provider:     prov,
+		configSource: configSource,
 		configsCache: make(map[provider.Resource]map[string]struct{}),
 	}
 }
@@ -30,17 +36,32 @@ func NewEgressController(prov provider.Provider, configsChan <-chan provider.Egr
 // Run runs the EgressController main loop.
 func (c *EgressController) Run(ctx context.Context) {
 	log.Info("Running controller")
-	interval := c.interval
+
 	for {
+		if !c.cacheInitialized {
+			configs, err := c.configSource.ListConfigs()
+			if err != nil {
+				log.Errorf("Failed to list Egress configurations: %v", err)
+				continue
+			}
+
+			c.cacheInitialized = true
+			for _, config := range configs {
+				if len(config.IPAddresses) > 0 {
+					c.configsCache[config.Resource] = config.IPAddresses
+				}
+			}
+			continue
+		}
+
 		select {
-		case <-time.After(interval):
+		case <-time.After(c.interval):
 			err := c.provider.Ensure(c.configsCache)
 			if err != nil {
 				log.Errorf("Failed to ensure configuration: %v", err)
 				continue
 			}
-			interval = c.interval
-		case config := <-c.configsChan:
+		case config := <-c.configSource.Config():
 			if len(config.IPAddresses) == 0 {
 				delete(c.configsCache, config.Resource)
 			} else {
@@ -53,7 +74,6 @@ func (c *EgressController) Run(ctx context.Context) {
 				log.Errorf("Failed to ensure configuration: %v", err)
 				continue
 			}
-			interval = c.interval
 		case <-ctx.Done():
 			log.Info("Terminating controller loop.")
 			return

--- a/kube/configmap.go
+++ b/kube/configmap.go
@@ -79,7 +79,7 @@ func (c *ConfigMapWatcher) add(obj interface{}) {
 	c.configs <- configMapToEgressConfig(cm)
 }
 
-func (c *ConfigMapWatcher) update(newObj, oldObj interface{}) {
+func (c *ConfigMapWatcher) update(oldObj, newObj interface{}) {
 	newCM, ok := newObj.(*v1.ConfigMap)
 	if !ok {
 		log.Errorf("Failed to get new ConfigMap object")
@@ -130,7 +130,7 @@ func configMapToEgressConfig(cm *v1.ConfigMap) provider.EgressConfig {
 	for key, cidr := range cm.Data {
 		_, ipnet, err := net.ParseCIDR(cidr)
 		if err != nil {
-			log.Errorf("Failed to parse CIDR %v from %s in ConfigMap %s/%s", cidr, key, cm.Namespace, cm.Name)
+			log.Errorf("Failed to parse CIDR '%s' from '%s' in ConfigMap %s/%s", cidr, key, cm.Namespace, cm.Name)
 			continue
 		}
 		ipAddresses[ipnet.String()] = struct{}{}

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func main() {
 
 	go cmWatcher.Run(ctx)
 
-	controller := controller.NewEgressController(p, configsChan, cfg.ResyncInterval)
+	controller := controller.NewEgressController(p, cmWatcher, cfg.ResyncInterval)
 	controller.Run(ctx)
 }
 


### PR DESCRIPTION
This fixes an issue where the controller would add/remove IPs on startup because it was handling config map events one by one and updating the egress CF stack for each event.

The fix is to initialize the cache once at startup by listing all egress configs discovered in the cluster. Once the cache is initialized it relies on watches to further update egress configurations in a reactive way.