### PR TITLE
Improvements for CF stacks

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"net"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -18,7 +19,7 @@ type EgressConfigSource interface {
 type EgressController struct {
 	interval         time.Duration
 	configSource     EgressConfigSource
-	configsCache     map[provider.Resource]map[string]struct{}
+	configsCache     map[provider.Resource]map[string]*net.IPNet
 	provider         provider.Provider
 	cacheInitialized bool
 }
@@ -29,7 +30,7 @@ func NewEgressController(prov provider.Provider, configSource EgressConfigSource
 		interval:     interval,
 		provider:     prov,
 		configSource: configSource,
-		configsCache: make(map[provider.Resource]map[string]struct{}),
+		configsCache: make(map[provider.Resource]map[string]*net.IPNet),
 	}
 }
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,7 @@ func (s mockEgressConfigSource) Config() <-chan provider.EgressConfig {
 }
 
 func TestControllerRun(t *testing.T) {
+	_, netA, _ := net.ParseCIDR("1.0.0.1/32")
 	prov := noop.NewNoopProvider()
 	configsChan := make(chan provider.EgressConfig)
 	configSource := mockEgressConfigSource{
@@ -32,8 +34,8 @@ func TestControllerRun(t *testing.T) {
 					Name:      "a",
 					Namespace: "y",
 				},
-				IPAddresses: map[string]struct{}{
-					"10.0.0.1": struct{}{},
+				IPAddresses: map[string]*net.IPNet{
+					netA.String(): netA,
 				},
 			},
 		},
@@ -64,8 +66,8 @@ func TestControllerRun(t *testing.T) {
 				Name:      "a",
 				Namespace: "x",
 			},
-			IPAddresses: map[string]struct{}{
-				"10.0.0.1": struct{}{},
+			IPAddresses: map[string]*net.IPNet{
+				netA.String(): netA,
 			},
 		}
 		cancel()

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 // indirect
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/apparentlymart/go-cidr v1.0.0
 	github.com/aws/aws-sdk-go v1.19.41
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a // indirect
 	github.com/crewjam/go-cloudformation v0.0.0-20170426160047-d3183a4759da

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 // indirect
 	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1yIonGp9761ExpPPV1ui0SAC59Yube9k=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/apparentlymart/go-cidr v1.0.0 h1:lGDvXx8Lv9QHjrAVP7jyzleG4F9+FkRhJcEsDFxeb8w=
+github.com/apparentlymart/go-cidr v1.0.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/aws/aws-sdk-go v1.19.41 h1:veutzvQP/lOmYmtX26S9mTFJLO6sp7/UsxFcCjglu4A=
 github.com/aws/aws-sdk-go v1.19.41/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a h1:BtpsbiV638WQZwhA98cEZw2BsbnQJrbd0BI7tsy0W1c=

--- a/kube/configmap.go
+++ b/kube/configmap.go
@@ -126,14 +126,14 @@ func (c *ConfigMapWatcher) Config() <-chan provider.EgressConfig {
 }
 
 func configMapToEgressConfig(cm *v1.ConfigMap) provider.EgressConfig {
-	ipAddresses := make(map[string]struct{})
+	ipAddresses := make(map[string]*net.IPNet)
 	for key, cidr := range cm.Data {
 		_, ipnet, err := net.ParseCIDR(cidr)
 		if err != nil {
 			log.Errorf("Failed to parse CIDR '%s' from '%s' in ConfigMap %s/%s", cidr, key, cm.Namespace, cm.Name)
 			continue
 		}
-		ipAddresses[ipnet.String()] = struct{}{}
+		ipAddresses[ipnet.String()] = ipnet
 	}
 
 	return provider.EgressConfig{

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -414,56 +414,6 @@ func TestEnsure(tt *testing.T) {
 	}
 }
 
-func TestGenerateRoutes(tt *testing.T) {
-	_, netA, _ := net.ParseCIDR("10.0.0.0/16")
-	_, netB, _ := net.ParseCIDR("10.0.0.0/17")
-	_, netC, _ := net.ParseCIDR("10.1.0.0/17")
-
-	for _, tc := range []struct {
-		msg      string
-		configs  map[provider.Resource]map[string]*net.IPNet
-		expected []string
-	}{
-		{
-			msg: "Subnet should be covered by superblock",
-			configs: map[provider.Resource]map[string]*net.IPNet{
-				provider.Resource{
-					Name:      "a",
-					Namespace: "x",
-				}: map[string]*net.IPNet{
-					netA.String(): netA,
-					netB.String(): netB,
-				},
-			},
-			expected: []string{
-				netA.String(),
-			},
-		},
-		{
-			msg: "non-overlapping subnets should be used.",
-			configs: map[provider.Resource]map[string]*net.IPNet{
-				provider.Resource{
-					Name:      "a",
-					Namespace: "x",
-				}: map[string]*net.IPNet{
-					netA.String(): netA,
-					netB.String(): netB,
-					netC.String(): netC,
-				},
-			},
-			expected: []string{
-				netC.String(),
-				netA.String(),
-			},
-		},
-	} {
-		tt.Run(tc.msg, func(t *testing.T) {
-			nets := generateRoutes(tc.configs)
-			require.Equal(t, tc.expected, nets)
-		})
-	}
-}
-
 func TestCloudformationHasTags(tt *testing.T) {
 	for _, tc := range []struct {
 		msg          string

--- a/provider/aws/naming.go
+++ b/provider/aws/naming.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	maxStackNameLen = 128
+	uuidLen         = 36
+	nameSeparator   = "-"
+	stackNamePrefix = "egress-static-nat"
+)
+
+var (
+	normalizationRegex = regexp.MustCompile("[^A-Za-z0-9-]+")
+	squeezeDashesRegex = regexp.MustCompile("[-]{2,}")
+)
+
+// normalizeStackName normalizes the stackName by normalizing the clusterID,
+// adding a stack name prefix and a uuid suffix.
+func normalizeStackName(clusterID string) string {
+	normalizedClusterID := squeezeDashesRegex.ReplaceAllString(
+		normalizationRegex.ReplaceAllString(clusterID, nameSeparator), nameSeparator)
+	lenClusterID := len(normalizedClusterID)
+	// max cluser ID length is the max stack name length except stack name
+	// prefix, UUID and two separators.
+	maxClusterIDLen := maxStackNameLen - len(stackNamePrefix) - uuidLen - 2
+	if lenClusterID > maxClusterIDLen {
+		normalizedClusterID = normalizedClusterID[lenClusterID-maxClusterIDLen:]
+	}
+	normalizedClusterID = strings.Trim(normalizedClusterID, nameSeparator) // trim leading/trailing separators
+
+	return fmt.Sprintf("%s%s%s%s%s", stackNamePrefix, nameSeparator, normalizedClusterID, nameSeparator, uuid.New().String())
+}

--- a/provider/aws/naming_test.go
+++ b/provider/aws/naming_test.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeStackName(t *testing.T) {
+	// test simple cluster ID
+	clusterID := "my-cluster"
+	normalized := normalizeStackName(clusterID)
+	expectedPrefix := stackNamePrefix + nameSeparator + clusterID + nameSeparator
+	if !strings.HasPrefix(normalized, expectedPrefix) {
+		t.Errorf("expected prefix %s, got %s", expectedPrefix, normalized)
+	}
+
+	// test that very long cluster ID gets cut off
+	longClusterID := strings.Repeat("a", maxStackNameLen)
+	normalized = normalizeStackName(longClusterID)
+	expectedClusterID := strings.Repeat("a", maxStackNameLen-len(stackNamePrefix)-uuidLen-2)
+	expectedPrefix = stackNamePrefix + nameSeparator + expectedClusterID + nameSeparator
+	if !strings.HasPrefix(normalized, expectedPrefix) {
+		t.Errorf("expected prefix %s, got %s", expectedPrefix, normalized)
+	}
+}

--- a/provider/cidr.go
+++ b/provider/cidr.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"net"
+	"sort"
+
+	"github.com/apparentlymart/go-cidr/cidr"
+)
+
+// GenerateRoutes generates the minimal number of needed routes based on a set
+// of routing configurations.
+func GenerateRoutes(configs map[Resource]map[string]*net.IPNet) []string {
+	cidrs := make([]*net.IPNet, 0, len(configs))
+	for _, rs := range configs {
+		for _, ipnet := range rs {
+			cidrs = append(cidrs, ipnet)
+		}
+	}
+
+	sort.Slice(cidrs, func(i, j int) bool {
+		countI := cidr.AddressCount(cidrs[i])
+		countJ := cidr.AddressCount(cidrs[j])
+		if countI == countJ {
+			return cidrs[i].String() < cidrs[j].String()
+		}
+		return countI < countJ
+	})
+
+	newCIDRs := make([]string, 0, len(cidrs))
+	i := 0
+	for _, c := range cidrs {
+		contained := false
+		if i < len(cidrs)-1 {
+			for _, block := range cidrs[i+1:] {
+				if networkContained(c, block) {
+					contained = true
+					break
+				}
+			}
+		}
+
+		if !contained {
+			newCIDRs = append(newCIDRs, c.String())
+		}
+		i++
+	}
+
+	return newCIDRs
+}
+
+// networkContained returns true if the subBlock is completely contained inside
+// the superBlock.
+func networkContained(subBlock, superBlock *net.IPNet) bool {
+	first, last := cidr.AddressRange(subBlock)
+	return superBlock.Contains(first) && superBlock.Contains(last)
+}

--- a/provider/cidr_test.go
+++ b/provider/cidr_test.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateRoutes(tt *testing.T) {
+	_, netA, _ := net.ParseCIDR("10.0.0.0/16")
+	_, netB, _ := net.ParseCIDR("10.0.0.0/17")
+	_, netC, _ := net.ParseCIDR("10.1.0.0/17")
+
+	for _, tc := range []struct {
+		msg      string
+		configs  map[Resource]map[string]*net.IPNet
+		expected []string
+	}{
+		{
+			msg: "Subnet should be covered by superblock",
+			configs: map[Resource]map[string]*net.IPNet{
+				Resource{
+					Name:      "a",
+					Namespace: "x",
+				}: map[string]*net.IPNet{
+					netA.String(): netA,
+					netB.String(): netB,
+				},
+			},
+			expected: []string{
+				netA.String(),
+			},
+		},
+		{
+			msg: "non-overlapping subnets should be used.",
+			configs: map[Resource]map[string]*net.IPNet{
+				Resource{
+					Name:      "a",
+					Namespace: "x",
+				}: map[string]*net.IPNet{
+					netA.String(): netA,
+					netB.String(): netB,
+					netC.String(): netC,
+				},
+			},
+			expected: []string{
+				netC.String(),
+				netA.String(),
+			},
+		},
+	} {
+		tt.Run(tc.msg, func(t *testing.T) {
+			nets := GenerateRoutes(tc.configs)
+			require.Equal(t, tc.expected, nets)
+		})
+	}
+}

--- a/provider/noop/noop.go
+++ b/provider/noop/noop.go
@@ -1,6 +1,8 @@
 package noop
 
 import (
+	"net"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/szuecs/kube-static-egress-controller/provider"
 )
@@ -17,7 +19,7 @@ func (p NoopProvider) String() string {
 	return ProviderName
 }
 
-func (p *NoopProvider) Ensure(configs map[provider.Resource]map[string]struct{}) error {
+func (p *NoopProvider) Ensure(configs map[provider.Resource]map[string]*net.IPNet) error {
 	log.Infof("%s Ensure(%v)", ProviderName, configs)
 	return nil
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,5 +1,7 @@
 package provider
 
+import "net"
+
 type Resource struct {
 	Name      string
 	Namespace string
@@ -7,10 +9,10 @@ type Resource struct {
 
 type EgressConfig struct {
 	Resource
-	IPAddresses map[string]struct{}
+	IPAddresses map[string]*net.IPNet
 }
 
 type Provider interface {
-	Ensure(configs map[Resource]map[string]struct{}) error
+	Ensure(configs map[Resource]map[string]*net.IPNet) error
 	String() string
 }


### PR DESCRIPTION
* Adds clusterID and Controller ID to CF stacks such that they can be identified (fix #31)
* Create new stacks with a dynamic stack name (using the same naming scheme as we use for kube-ingress-aws-controller). If the stack already exists with the name `static-egress-nat` keep using that name to avoid changing ElasticIPs. (Fix #32)
* Reduce configured routes by dropping CIDRs contained inside other configured CIDRs if any. E.g. if you configure `10.0.0.0/16` and `10.0.0.0/17` only configure `10.0.0.0/16`.