### PR TITLE
Initialize map before assignment

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,9 @@ var defaultConfig = &Config{
 }
 
 func NewConfig() *Config {
-	return &Config{}
+	return &Config{
+		AdditionalStackTags: make(map[string]string),
+	}
 }
 
 func newProvider(clusterID, controllerID string, dry bool, name, vpcID string, natCidrBlocks, availabilityZones []string, stackTerminationProtection bool, additionalStackTags map[string]string) provider.Provider {

--- a/main_test.go
+++ b/main_test.go
@@ -12,7 +12,9 @@ func TestNewConfig(t *testing.T) {
 	}{
 		{
 			name: "test-new-config",
-			want: &Config{},
+			want: &Config{
+				AdditionalStackTags: make(map[string]string),
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Initialize the `AdditionalStackTags` map before used in the flag assignment to avoid:

```
panic: assignment to entry in nil map
```