### PR TITLE
Prometheus metric for last successful sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/linki/instrumented_http v0.3.0
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.3.0 // indirect
+	github.com/prometheus/client_golang v1.3.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect


### PR DESCRIPTION
- Serving Prometheus Metrics Handler
- Adding a Prometheus metric to see when static-egress-controller had the
last successful sync.