### PR TITLE
Updating lastSyncTimestamp on a regular interval

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -77,6 +77,8 @@ func (c *EgressController) Run(ctx context.Context) {
 				log.Errorf("Failed to ensure configuration: %v", err)
 				continue
 			}
+			// successfully synced
+			lastSyncTimestamp.SetToCurrentTime()
 		case config := <-c.configSource.Config():
 			if len(config.IPAddresses) == 0 {
 				delete(c.configsCache, config.Resource)
@@ -90,9 +92,6 @@ func (c *EgressController) Run(ctx context.Context) {
 				log.Errorf("Failed to ensure configuration: %v", err)
 				continue
 			}
-
-			// successfully synced
-			lastSyncTimestamp.SetToCurrentTime()
 		case <-ctx.Done():
 			log.Info("Terminating controller loop.")
 			return

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -92,6 +92,8 @@ func (c *EgressController) Run(ctx context.Context) {
 				log.Errorf("Failed to ensure configuration: %v", err)
 				continue
 			}
+			// successfully synced
+			lastSyncTimestamp.SetToCurrentTime()
 		case <-ctx.Done():
 			log.Info("Terminating controller loop.")
 			return


### PR DESCRIPTION
Because this is where we resync, it will happen at a regular interval,
otherwise we can risk the synctimestamp metric is very old if no
configmaps are changed/updated/deleted.

Signed-off-by: Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>