### PR TITLE
Fix parsing of additional-stack-tags flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ type Config struct {
 	// required by AWS provider
 	AvailabilityZones          []string
 	StackTerminationProtection bool
-	AdditionalStackTags        map[string]string
+	AdditionalStackTags        StringMap
 	Namespace                  string
 	ResyncInterval             time.Duration
 	Address                    string
@@ -123,7 +123,7 @@ Example:
 	app.Flag("aws-nat-cidr-block", "AWS Provider requires to specify NAT-CIDR-Blocks for each AZ to have a NAT gateway in. Each should be a small network having only the NAT GW").StringsVar(&cfg.NatCidrBlocks)
 	app.Flag("aws-az", "AWS Provider requires to specify all AZs to have a NAT gateway in.").StringsVar(&cfg.AvailabilityZones)
 	app.Flag("stack-termination-protection", "Enables AWS clouformation stack termination protection for the stacks managed by the controller.").BoolVar(&cfg.StackTerminationProtection)
-	app.Flag("additional-stack-tags", "Set additional custom tags on the Cloudformation Stacks managed by the controller.").StringMapVar(&cfg.AdditionalStackTags)
+	app.Flag("additional-stack-tags", "Set additional custom tags on the Cloudformation Stacks managed by the controller.").SetValue(&cfg.AdditionalStackTags)
 	app.Flag("resync-interval", "Resync interval to make sure current state is actual state.").Default("5m").DurationVar(&cfg.ResyncInterval)
 	app.Flag("dry-run", "When enabled, prints changes rather than actually performing them (default: disabled)").BoolVar(&cfg.DryRun)
 	app.Flag("log-level", "Set the level of logging. (default: info, options: panic, debug, info, warn, error, fatal").Default(defaultConfig.LogLevel).EnumVar(&cfg.LogLevel, allLogLevelsAsStrings()...)

--- a/string_map.go
+++ b/string_map.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// StringMap is a map of key value pairs.
+type StringMap map[string]string
+
+func (s StringMap) String() string {
+	elements := make([]string, 0, len(s))
+	for k, v := range s {
+		elements = append(elements, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(elements, ",")
+}
+
+// Set parses a string of the format: `key=value`.
+func (s StringMap) Set(value string) error {
+	if s == nil {
+		s = StringMap(map[string]string{})
+	}
+
+	kv := strings.Split(value, "=")
+	if len(kv) != 2 {
+		return fmt.Errorf("invalid key=value format: %s", value)
+	}
+
+	s[kv[0]] = kv[1]
+
+	return nil
+}
+
+// IsCumulative always return true because it's allowed to call Set multiple
+// times.
+func (_ StringMap) IsCumulative() bool {
+	return true
+}

--- a/string_map_test.go
+++ b/string_map_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringMapString(t *testing.T) {
+	stringMap := StringMap(map[string]string{
+		"master": "true",
+	})
+	expected := "master=true"
+
+	if stringMap.String() != expected {
+		t.Errorf("expected %s, got %s", expected, stringMap.String())
+	}
+
+}
+
+func TestSetStringMapValue(t *testing.T) {
+	for _, tc := range []struct {
+		msg      string
+		value    string
+		valid    bool
+		expected map[string]string
+	}{
+		{
+			msg:   "test valid stringMap",
+			value: "key=value",
+			valid: true,
+			expected: map[string]string{
+				"key": "value",
+			},
+		},
+		{
+			msg:   "test invalid stringMap",
+			value: "key:value",
+			valid: false,
+		},
+		{
+			msg:   "test valid stringMap with 'complex' key",
+			value: "complex/key/1:2:3=value",
+			valid: true,
+			expected: map[string]string{
+				"complex/key/1:2:3": "value",
+			},
+		},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			stringMap := StringMap(map[string]string{})
+			err := stringMap.Set(tc.value)
+			if err != nil && tc.valid {
+				t.Errorf("should not fail: %s", err)
+			}
+
+			if err == nil && !tc.valid {
+				t.Error("expected failure")
+			}
+
+			if tc.valid {
+				require.Equal(t, tc.expected, map[string]string(stringMap))
+			}
+		})
+	}
+}
+
+func TestStringMapIsCumulative(t *testing.T) {
+	var stringMap StringMap
+	if !stringMap.IsCumulative() {
+		t.Error("expected IsCumulative = true")
+	}
+}


### PR DESCRIPTION
For the migration mentioned in #43 we wanted to use the flag: `--additional-stack-tags=zalando.org/cluster/aws:<id>:<region>:..=owned`

This didn't work because [kingpin splits a key-value pair based on `=` OR `:`](https://github.com/alecthomas/kingpin/blob/551b91efb55733c0a62f598ed07996735c446326/values.go#L157) and in this case it split the key after: `zalando.org/cluster/aws:` :facepalm: 

This fixes the issue by implementing a custom flag parser for key-value pairs that only support `=` as the splitting character which enables us to use the value we want to.