### PR TITLE
Update dockerfile, missing TARGETARCH var to ADD binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ MAINTAINER Team Teapot @ Zalando SE <team-teapot@zalando.de>
 
 # add binary
 ARG TARGETARCH
-ADD build/linux/kube-static-egress-controller /
+ADD build/linux/${TARGETARCH}/kube-static-egress-controller /
 
 ENTRYPOINT ["/kube-static-egress-controller"]


### PR DESCRIPTION
Missing change from previous PR https://github.com/szuecs/kube-static-egress-controller/pull/46. 

After merge, please create the tag `v0.2.12` to be used in https://github.bus.zalan.do/teapot/kube-static-egress-controller-build/blob/master/delivery.yaml#L13 :pray: .