### PR TITLE
Drop identifying stack based on name alone

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -683,7 +683,7 @@ func (p *AWSProvider) getEgressStack(ctx context.Context) (cftypes.Stack, error)
 		}
 
 		for _, stack := range resp.Stacks {
-			if cloudformationHasTags(tags, stack.Tags) || aws.ToString(stack.StackName) == staticLagacyStackName {
+			if cloudformationHasTags(tags, stack.Tags) {
 				egressStack = stack
 				break
 			}


### PR DESCRIPTION
This removes the logic to identify the egress stack only based on stack name. This was needed in the past for a migration to the non-static stack naming, but it's not desired if all egress stacks have ownership tags.

The motivation for removing is that if you run two clusters in a single AWS account region and there is an existing stack with the legacy name owned by one cluster, then the other cluster could delete the stack because it doesn't check ownership if it just checks the name.

This change assumes all egress stacks across the environment has proper clusterID/ownership tags.